### PR TITLE
Enable Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,12 @@
+dist: xenial
+language: node_js
+
+node_js:
+  - 12
+  - 10
+
+install:
+   - npm install
+
+script:
+   - npm test


### PR DESCRIPTION
Enable Travis CI builds for NodeJS 10.x and 12.x .