### PR TITLE
Fix security regression

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -21,7 +21,7 @@ function ensureFunction(option, defaultValue) {
         return () => defaultValue;
     }
 
-    if (typeof option != 'function') {
+    if (typeof option !== 'function') {
         return () => option;
     }
 
@@ -40,12 +40,12 @@ function buildMiddleware(options) {
     const getResponseBody = ensureFunction(options.unauthorizedResponse, '');
     const realm = ensureFunction(options.realm);
 
-    assert(typeof users == 'object', 'Expected an object for the basic auth users, found ' + typeof users + ' instead');
-    assert(typeof authorizer == 'function', 'Expected a function for the basic auth authorizer, found ' + typeof authorizer + ' instead');
+    assert(typeof users === 'object', `Expected an object for the basic auth users, found ${typeof users} instead`);
+    assert(typeof authorizer === 'function', `Expected a function for the basic auth authorizer, found ${typeof authorizer} instead`);
 
     function staticUsersAuthorizer(username, password) {
         for (let i in users) {
-            if (safeCompare(username, i) && safeCompare(password, users[i])) {
+            if (safeCompare(username, i) & safeCompare(password, users[i])) {
                 return true;
             }
         }
@@ -75,11 +75,11 @@ function buildMiddleware(options) {
 
         function unauthorized () {
             if (challenge) {
+                const realmName = realm(req);
                 let challengeString = 'Basic';
-                let realmName = realm(req);
 
                 if (realmName) {
-                    challengeString += ' realm="' + realmName + '"';
+                    challengeString += ` realm="${realmName}"`;
                 }
 
                 res.set('WWW-Authenticate', challengeString);
@@ -88,7 +88,7 @@ function buildMiddleware(options) {
             //TODO: Allow response body to be JSON (maybe autodetect?)
             const response = getResponseBody(req);
 
-            if (typeof response == 'string') {
+            if (typeof response === 'string') {
                 return res.status(401).send(response);
             }
 


### PR DESCRIPTION
* Use `&` instead of `&&` to avoid short-circuiting (to protect against timing attacks). This fixes a recently introduced regression.
* Use strict comparisons for `typeof` results.