### PR TITLE
Automate NPM publish on release

### DIFF
--- a/.github/main.workflow
+++ b/.github/main.workflow
@@ -1,0 +1,10 @@
+workflow "NPM publish" {
+  on = "release"
+  resolves = ["Publish"]
+}
+
+action "Publish" {
+  uses = "actions/npm@59b64a598378f31e49cb76f27d6f3312b582f680"
+  args = "publish --access public"
+  secrets = ["NPM_AUTH_TOKEN"]
+}


### PR DESCRIPTION
Use Github Actions to automate publishing new package versions to NPM every time a new release is defined.