### PR TITLE
Mark local state as const

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -45,7 +45,7 @@ function buildMiddleware(options) {
 
     function staticUsersAuthorizer(username, password) {
         let authorized = false;
-        for (let i in users) {
+        for (const i in users) {
             authorized |= safeCompare(username, i) & safeCompare(password, users[i]);
         }
         return authorized;
@@ -81,11 +81,9 @@ function buildMiddleware(options) {
         function unauthorized () {
             if (challenge) {
                 const realmName = realm(req);
-                let challengeString = 'Basic';
-
-                if (realmName) {
-                    challengeString += ` realm="${realmName}"`;
-                }
+                const challengeString = (realmName)
+                    ? `Basic realm="${realmName}"`
+                    : 'Basic';
 
                 res.set('WWW-Authenticate', challengeString);
             }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "spresso-authy",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Plug & play basic auth middleware for express",
   "main": "lib/index.js",
   "types": "lib/spresso-authy.d.ts",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,9 @@
     "test-lite": "nyc mocha tests/*.test.js",
     "test": "npm run test-lite && npm run check-dts && npm run lint"
   },
-  "files": ["/lib"],
+  "files": [
+    "/lib"
+  ],
   "repository": {
     "type": "git",
     "url": "git+https://github.com/castarco/spresso-authy.git"
@@ -44,6 +46,6 @@
     "nyc": "^14.1.1",
     "should": "^13.2.3",
     "supertest": "^4.0.2",
-    "typescript": "^3.5.2"
+    "typescript": "^3.5.3"
   }
 }


### PR DESCRIPTION
Mark more local state as const to help JITs doing a better job optimizing, also to simplify static code analysis.